### PR TITLE
Update bitski-provider dependency to 0.6.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -79,9 +79,9 @@
       },
       "dependencies": {
         "async": {
-          "version": "3.0.0",
-          "resolved": "https://registry.npmjs.org/async/-/async-3.0.0.tgz",
-          "integrity": "sha512-LNZ6JSpKraIia6VZKKbKxmX6nWIdfsG7WqrOvKpCuDjH7BnGyQRFMTSXEe8to2WF/rqoAKgZvj+L5nnxe0suAg=="
+          "version": "3.0.1",
+          "resolved": "https://registry.npmjs.org/async/-/async-3.0.1.tgz",
+          "integrity": "sha512-ZswD8vwPtmBZzbn9xyi8XBQWXH3AvOQ43Za1KWYq7JeycrZuUYzx01KvHcVbXltjqH4y0MWrQ33008uLTqXuDw=="
         }
       }
     },
@@ -915,9 +915,9 @@
       "integrity": "sha512-S4XzBk5sMB+Rcb/LNcpzXr57VRTxgAvaAEDAl1AwRx27j00hT84O6OkteE7u8UB3NuaaygCRrEpqox4uDOrbdQ=="
     },
     "bitski-provider": {
-      "version": "0.6.0-alpha.1",
-      "resolved": "https://registry.npmjs.org/bitski-provider/-/bitski-provider-0.6.0-alpha.1.tgz",
-      "integrity": "sha512-ys/4rLMZ0FRAUkxJ7azZ7EIjh+XlXJLaTtGacChk2NRtTz5l6qRFk+4HKHVwiby+u5qUUX9049fi1XPI9vsfyQ==",
+      "version": "0.6.0",
+      "resolved": "https://registry.npmjs.org/bitski-provider/-/bitski-provider-0.6.0.tgz",
+      "integrity": "sha512-l5MwAqdBjXQVyG2VplYu53uwis1M9JBWhga5vx7emLf6nnrZg8YI9o5RnXBEJ0GUiFwf+9H6zYT+J7WboTyASA==",
       "requires": {
         "@bitski/provider-engine": "^0.2.0",
         "@types/ethereum-protocol": "^1.0.0",

--- a/package.json
+++ b/package.json
@@ -19,7 +19,7 @@
   "author": "",
   "license": "ISC",
   "dependencies": {
-    "bitski-provider": "^0.6.0-alpha.1",
+    "bitski-provider": "^0.6.0",
     "simple-oauth2": "^2.2.0"
   },
   "devDependencies": {

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,3 +1,4 @@
+import { BitskiEngineOptions } from 'bitski-provider';
 import CredentialTokenProvider from './auth/credential-token-provider';
 import BitskiNodeProvider from './provider';
 
@@ -12,7 +13,7 @@ export interface Credential {
 /**
  * Additional options to create a provider with
  */
-export interface ProviderOptions {
+export interface ProviderOptions extends BitskiEngineOptions {
   // Ethereum network to use (mainnet, rinkeby, kovan). default: mainnet
   networkName?: string;
   // deprecated - use networkName instead

--- a/src/subproviders/fetch.ts
+++ b/src/subproviders/fetch.ts
@@ -1,5 +1,5 @@
 import { AuthenticatedFetchSubprovider } from 'bitski-provider';
-import * as https from 'https';
+import { Agent } from 'https';
 
 export class NodeFetchSubprovider extends AuthenticatedFetchSubprovider {
 
@@ -7,7 +7,7 @@ export class NodeFetchSubprovider extends AuthenticatedFetchSubprovider {
     const parameters: any = super.generateParameters(payload, accessToken);
 
     // Bitski's servers require TLS 1.2 or greater
-    const agent = new https.Agent({
+    const agent = new Agent({
       secureProtocol: 'TLSv1_2_method',
     });
 


### PR DESCRIPTION
Pull in updates from the main package now that it is released. Only change to support it is to make ProviderOptions extend the new BitskiEngineOptions.