### PR TITLE
Add support for newer versions of web3 via bitski-provider

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -62,9 +62,9 @@
       }
     },
     "@bitski/provider-engine": {
-      "version": "0.2.0",
-      "resolved": "https://registry.npmjs.org/@bitski/provider-engine/-/provider-engine-0.2.0.tgz",
-      "integrity": "sha512-u0qhCJ03MxhXLvbW3CmCRQ1F4Y7ivRzKdrI5W3qllKzZwUYbASl/YqvFn2uiCPWuq2YT9NCekh1ck47lQC6fyg==",
+      "version": "0.4.1",
+      "resolved": "https://registry.npmjs.org/@bitski/provider-engine/-/provider-engine-0.4.1.tgz",
+      "integrity": "sha512-/10Dc5WmnR4mt2tY6oHmr6UXGjg/HY2bKxLLPuwlTGrr8w3zIyxXcSkAENBDA/QVZBxrpajb2P/Lt9GhEdfr3A==",
       "requires": {
         "async": "^3.0.0",
         "bn.js": "^4.11.8",
@@ -83,14 +83,6 @@
           "resolved": "https://registry.npmjs.org/async/-/async-3.0.1.tgz",
           "integrity": "sha512-ZswD8vwPtmBZzbn9xyi8XBQWXH3AvOQ43Za1KWYq7JeycrZuUYzx01KvHcVbXltjqH4y0MWrQ33008uLTqXuDw=="
         }
-      }
-    },
-    "@types/ethereum-protocol": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/@types/ethereum-protocol/-/ethereum-protocol-1.0.0.tgz",
-      "integrity": "sha512-3DiI3Zxf81CgX+VhxNNFJBv/sfr1BFBKQK2sQ85hU9FwWJJMWV5gRDV79OUNShiwj3tYYIezU94qpucsb3dThQ==",
-      "requires": {
-        "bignumber.js": "7.2.1"
       }
     },
     "@types/jest": {
@@ -909,18 +901,12 @@
         "tweetnacl": "^0.14.3"
       }
     },
-    "bignumber.js": {
-      "version": "7.2.1",
-      "resolved": "https://registry.npmjs.org/bignumber.js/-/bignumber.js-7.2.1.tgz",
-      "integrity": "sha512-S4XzBk5sMB+Rcb/LNcpzXr57VRTxgAvaAEDAl1AwRx27j00hT84O6OkteE7u8UB3NuaaygCRrEpqox4uDOrbdQ=="
-    },
     "bitski-provider": {
-      "version": "0.6.0",
-      "resolved": "https://registry.npmjs.org/bitski-provider/-/bitski-provider-0.6.0.tgz",
-      "integrity": "sha512-l5MwAqdBjXQVyG2VplYu53uwis1M9JBWhga5vx7emLf6nnrZg8YI9o5RnXBEJ0GUiFwf+9H6zYT+J7WboTyASA==",
+      "version": "0.7.0-alpha.0",
+      "resolved": "https://registry.npmjs.org/bitski-provider/-/bitski-provider-0.7.0-alpha.0.tgz",
+      "integrity": "sha512-etb2r9p5cxJ5gUCrPK7NecqcZLWA+sIYH9ouwON28VWC56iIG1O3gnmjSDZ1sLfPaHoo8CzVP0NXXgdE3Cz52A==",
       "requires": {
-        "@bitski/provider-engine": "^0.2.0",
-        "@types/ethereum-protocol": "^1.0.0",
+        "@bitski/provider-engine": "^0.4.1",
         "json-rpc-error": "^2.0.0"
       }
     },

--- a/package.json
+++ b/package.json
@@ -19,7 +19,7 @@
   "author": "",
   "license": "ISC",
   "dependencies": {
-    "bitski-provider": "^0.6.0",
+    "bitski-provider": "^0.7.0-alpha.0",
     "simple-oauth2": "^2.2.0"
   },
   "devDependencies": {


### PR DESCRIPTION
Bump bitski-provider version to 0.7.0-alpha.0 to support latest web3.