### PR TITLE
Add better error handling, and add better typing

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -62,9 +62,9 @@
       }
     },
     "@bitski/provider-engine": {
-      "version": "0.4.1",
-      "resolved": "https://registry.npmjs.org/@bitski/provider-engine/-/provider-engine-0.4.1.tgz",
-      "integrity": "sha512-/10Dc5WmnR4mt2tY6oHmr6UXGjg/HY2bKxLLPuwlTGrr8w3zIyxXcSkAENBDA/QVZBxrpajb2P/Lt9GhEdfr3A==",
+      "version": "0.6.1",
+      "resolved": "https://registry.npmjs.org/@bitski/provider-engine/-/provider-engine-0.6.1.tgz",
+      "integrity": "sha512-i4H9oKhhDEqQbtn8xHgtyD42W3uM/tAr/uizDHebdsSFfwlXxGSKuJv8gEhePE2m6vbUPCbuhEQ52eMp7NCdog==",
       "requires": {
         "async": "^3.0.0",
         "bn.js": "^4.11.8",
@@ -79,9 +79,9 @@
       },
       "dependencies": {
         "async": {
-          "version": "3.0.1",
-          "resolved": "https://registry.npmjs.org/async/-/async-3.0.1.tgz",
-          "integrity": "sha512-ZswD8vwPtmBZzbn9xyi8XBQWXH3AvOQ43Za1KWYq7JeycrZuUYzx01KvHcVbXltjqH4y0MWrQ33008uLTqXuDw=="
+          "version": "3.1.0",
+          "resolved": "https://registry.npmjs.org/async/-/async-3.1.0.tgz",
+          "integrity": "sha512-4vx/aaY6j/j3Lw3fbCHNWP0pPaTCew3F6F3hYyl/tHs/ndmV1q7NW9T5yuJ2XAGwdQrP+6Wu20x06U4APo/iQQ=="
         }
       }
     },
@@ -902,12 +902,20 @@
       }
     },
     "bitski-provider": {
-      "version": "0.7.0-alpha.0",
-      "resolved": "https://registry.npmjs.org/bitski-provider/-/bitski-provider-0.7.0-alpha.0.tgz",
-      "integrity": "sha512-etb2r9p5cxJ5gUCrPK7NecqcZLWA+sIYH9ouwON28VWC56iIG1O3gnmjSDZ1sLfPaHoo8CzVP0NXXgdE3Cz52A==",
+      "version": "0.9.0",
+      "resolved": "https://registry.npmjs.org/bitski-provider/-/bitski-provider-0.9.0.tgz",
+      "integrity": "sha512-/MZ9GmEQTrblEfZBpJj2aEYzyulPgSYV/A5fE8A6ybUcf6rXOZkDJ4HDD5MbXufHalhXQqd9CyvRzvDi+jSkCg==",
       "requires": {
-        "@bitski/provider-engine": "^0.4.1",
+        "@bitski/provider-engine": "^0.6.1",
+        "async": "3.0.1",
         "json-rpc-error": "^2.0.0"
+      },
+      "dependencies": {
+        "async": {
+          "version": "3.0.1",
+          "resolved": "https://registry.npmjs.org/async/-/async-3.0.1.tgz",
+          "integrity": "sha512-ZswD8vwPtmBZzbn9xyi8XBQWXH3AvOQ43Za1KWYq7JeycrZuUYzx01KvHcVbXltjqH4y0MWrQ33008uLTqXuDw=="
+        }
       }
     },
     "bn.js": {
@@ -6487,9 +6495,9 @@
       "dev": true
     },
     "xtend": {
-      "version": "4.0.1",
-      "resolved": "https://registry.npmjs.org/xtend/-/xtend-4.0.1.tgz",
-      "integrity": "sha1-pcbVMr5lbiPbgg77lDofBJmNY68="
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/xtend/-/xtend-4.0.2.tgz",
+      "integrity": "sha512-LKYU1iAXJXUgAXn9URjiu+MWhyUXHsvfp7mcuYm9dSUKK0/CjtrUwFAxD82/mCWbtLsGjFIad0wIsod4zrTAEQ=="
     },
     "y18n": {
       "version": "3.2.1",

--- a/package.json
+++ b/package.json
@@ -19,7 +19,7 @@
   "author": "",
   "license": "ISC",
   "dependencies": {
-    "bitski-provider": "^0.7.0-alpha.0",
+    "bitski-provider": "^0.9.0",
     "simple-oauth2": "^2.2.0"
   },
   "devDependencies": {

--- a/src/auth/anonymous-token-provider.ts
+++ b/src/auth/anonymous-token-provider.ts
@@ -1,0 +1,18 @@
+import { AccessTokenProvider } from 'bitski-provider';
+import { AuthenticationError } from '../errors/authentication-error';
+
+/**
+ * A token provider for clients that do not use App Wallet.
+ * Public requests will work fine, but logged in requests will always fail.
+ */
+export class AnonymousTokenProvider implements AccessTokenProvider {
+
+  public getAccessToken(): Promise<string> {
+    throw AuthenticationError.NoAccessToken();
+  }
+
+  public invalidateToken(): Promise<void> {
+    return Promise.resolve();
+  }
+
+}

--- a/src/auth/credential-token-provider.ts
+++ b/src/auth/credential-token-provider.ts
@@ -1,5 +1,7 @@
 import { AccessToken, AccessTokenProvider } from 'bitski-provider';
 import { create as OAuth2 } from 'simple-oauth2';
+import { AuthenticationError } from '../errors/authentication-error';
+import { Credential } from '../index';
 
 const DEFAULT_TOKEN_OPTIONS = { scope: 'eth_sign' };
 const DEFAULT_AUTH_OPTIONS = {
@@ -17,13 +19,13 @@ export default class CredentialTokenProvider implements AccessTokenProvider {
   protected accessToken?: AccessToken;
   protected options: any;
 
-  constructor(credentials: any, options: any) {
+  constructor(credentials: Credential, options: any) {
+    this.options = Object.assign({}, DEFAULT_TOKEN_OPTIONS, options);
     const oauthSettings = Object.assign({ client: credentials }, DEFAULT_AUTH_OPTIONS);
     try {
       this.oauthClient = OAuth2(oauthSettings);
-      this.options = Object.assign({}, DEFAULT_TOKEN_OPTIONS, options);
     } catch (e) {
-      throw new Error('Invalid credentials provided. Please check your credentials format and try again.');
+      throw AuthenticationError.InvalidCredentials(e);
     }
   }
 
@@ -46,6 +48,8 @@ export default class CredentialTokenProvider implements AccessTokenProvider {
       const token = new AccessToken(result.access_token, result.expires_in);
       this.accessToken = token;
       return token;
+    }).catch((error) => {
+      throw AuthenticationError.AuthenticationFailed(error);
     });
   }
 

--- a/src/errors/authentication-error.ts
+++ b/src/errors/authentication-error.ts
@@ -1,0 +1,42 @@
+export enum AuthenticationErrorCode {
+  // Attempted to take an action that requires an access token, when none was available.
+  NoAccessToken = 1000,
+  // The credentials provided are invalid.
+  InvalidCredentials = 1001,
+  // Authentication using the credentials provided failed.
+  AuthenticationFailed = 1002,
+}
+
+export class AuthenticationError extends Error {
+
+  public static NoAccessToken(): AuthenticationError {
+    return new AuthenticationError('This request requires an app wallet.', AuthenticationErrorCode.NoAccessToken);
+  }
+
+  public static InvalidCredentials(underlyingError?: Error): AuthenticationError {
+    const err = new AuthenticationError('The credentials provided are not valid.', AuthenticationErrorCode.InvalidCredentials);
+    err.underlyingError = underlyingError;
+    return err;
+  }
+
+  public static AuthenticationFailed(underlyingError?: Error): AuthenticationError {
+    const err = new AuthenticationError('Authentication failed. Please verify your credentials and try again.', AuthenticationErrorCode.AuthenticationFailed);
+    err.underlyingError = underlyingError;
+    return err;
+  }
+
+  public name: string = 'AuthenticationError';
+  public code: AuthenticationErrorCode;
+
+  // Underlying error, if available
+  public underlyingError?: Error;
+
+  constructor(message: string, code: AuthenticationErrorCode) {
+    super(message);
+    if (Error.captureStackTrace) {
+      Error.captureStackTrace(this, AuthenticationError);
+    }
+    this.code = code;
+  }
+
+}

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,4 +1,5 @@
-import { BitskiEngineOptions } from 'bitski-provider';
+import { AccessTokenProvider, BitskiEngineOptions } from 'bitski-provider';
+import { AnonymousTokenProvider } from './auth/anonymous-token-provider';
 import CredentialTokenProvider from './auth/credential-token-provider';
 import BitskiNodeProvider from './provider';
 
@@ -33,9 +34,17 @@ export interface ProviderOptions extends BitskiEngineOptions {
  */
 export function getProvider(clientId: string, options?: ProviderOptions): BitskiNodeProvider {
   const opts = options || {};
-  const tokenProvider = new CredentialTokenProvider(opts.credentials || {}, opts.oauth);
+  let tokenProvider: AccessTokenProvider;
+  if (opts.credentials) {
+    // Create a credential token provider if using app wallet.
+    tokenProvider = new CredentialTokenProvider(opts.credentials, opts.oauth);
+  } else {
+    // Create a logged out token provider if not using app wallet.
+    tokenProvider = new AnonymousTokenProvider();
+  }
   // Check opts.network as well for backwards compatibility
   const network = opts.networkName || opts.network;
+  // Create the provider
   const provider = new BitskiNodeProvider(clientId, tokenProvider, network, opts);
   provider.start();
   return provider;

--- a/src/provider-manager.ts
+++ b/src/provider-manager.ts
@@ -1,17 +1,26 @@
-import { getProvider as createProvider } from './index';
+import CredentialTokenProvider from './auth/credential-token-provider';
 import BitskiNodeProvider from './provider';
 
 /**
- * A wrapper around Bitski providers for convenient use with Truffle
+ * A wrapper around Bitski providers for convenient use with Truffle.
+ *
+ * Background:
+ * This is very useful because when you pass a custom provider to Truffle via a
+ * function in the config, it executes that function many times during execution,
+ * which will cause you to create a brand new provider for every request.
+ * This caches a single provider for every network, which reduces the memory
+ * footprint, and vastly speeds up execution. It also shares an access token provider
+ * amongst all providers, which means that if you switch networks, it should also be
+ * very quick.
  */
 export class ProviderManager {
   private credential: string;
-  private secret: string;
   private cachedProviders: Map<string, BitskiNodeProvider> = new Map();
+  private tokenProvider: CredentialTokenProvider;
 
-  constructor(credential, secret) {
+  constructor(credential: string, secret: string) {
     this.credential = credential;
-    this.secret = secret;
+    this.tokenProvider = new CredentialTokenProvider({ id: credential, secret }, {});
   }
 
   public getProvider(networkName: string = 'mainnet', additionalHeaders?: object): BitskiNodeProvider {
@@ -21,17 +30,11 @@ export class ProviderManager {
       // Return existing provider
       return existingProvider;
     }
-    // Generate options
-    const options = {
-      networkName,
-      additionalHeaders,
-      credentials: {
-        id: this.credential,
-        secret: this.secret,
-      },
-    };
-    // Create provider
-    const newProvider = createProvider(this.credential, options);
+
+    // ** No existing provider, create one **
+    const newProvider = new BitskiNodeProvider(this.credential, this.tokenProvider, networkName, { additionalHeaders });
+    // Start the provider
+    newProvider.start();
     // Cache
     this.cachedProviders.set(networkName, newProvider);
     // Return newly created provider

--- a/src/provider.ts
+++ b/src/provider.ts
@@ -1,5 +1,4 @@
-import { BitskiEngine } from 'bitski-provider';
-import CredentialTokenProvider from './auth/credential-token-provider';
+import { AccessTokenProvider, BitskiEngine } from 'bitski-provider';
 import { ProviderOptions } from './index';
 import { NodeFetchSubprovider } from './subproviders/fetch';
 
@@ -9,17 +8,17 @@ import { NodeFetchSubprovider } from './subproviders/fetch';
 export default class BitskiNodeProvider extends BitskiEngine {
   public rpcUrl: string;
   public clientId: string;
-  private tokenProvider: CredentialTokenProvider;
+  private tokenProvider: AccessTokenProvider;
   private headers: object;
 
   /**
    * Creates a new BitskiNodeProvider
    * @param clientId Client id
-   * @param tokenProvider A CredentialTokenProvider for getting access tokens
+   * @param tokenProvider An AccessTokenProvider instance for getting access tokens
    * @param networkName Ethereum network to use. Default: mainnet
    * @param options Additional options
    */
-  constructor(clientId: string, tokenProvider: CredentialTokenProvider, networkName?: string, options?: ProviderOptions) {
+  constructor(clientId: string, tokenProvider: AccessTokenProvider, networkName?: string, options?: ProviderOptions) {
     super(options);
     this.clientId = clientId;
     this.rpcUrl = `https://api.bitski.com/v1/web3/${networkName || 'mainnet'}`;


### PR DESCRIPTION
The goal with this PR is to account for all the known errors that we throw from the SDK, and enumerate them with a set of common codes and types. Closer investigation revealed potential issues with creating a CredentialTokenProvider unnecessarily.

- Add new AuthenticationError type to account for errors in the Node sdk
- Add Credential type to CredentialTokenProvider's constructor, and only create one if credentials are passed
- Add a new AnonymousTokenProvider type to account for Node users who do not use App Wallet
- Update BitskiNodeProvider to take any form of AccessTokenProvider instead of strictly relying on CredentialTokenProvider
- Share a token provider between multiple web3 provider instances in provider manager
- Bump bitski-provider to 0.9.0 to pull in better errors in the provider-engine stack